### PR TITLE
Fix styles for the list of benefits

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.js
+++ b/src/components/common/FeatureBox/FeatureBox.js
@@ -5,8 +5,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './FeatureBox.module.scss';
 
-const FeatureBox = ({ active, icon, children }) => (
-  <div className={styles.root + (active ? ' ' + styles.active : '')}>
+const FeatureBox = ({ icon, children }) => (
+  <div className={styles.root}>
     {icon && (
       <div className={styles.iconWrapper}>
         <FontAwesomeIcon className={styles.icon} icon={icon} />
@@ -19,7 +19,6 @@ const FeatureBox = ({ active, icon, children }) => (
 FeatureBox.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.object,
-  active: PropTypes.bool,
 };
 
 export default FeatureBox;

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -60,7 +60,7 @@
     p {
     }
   }
-
+  &:hover,
   &.active {
     .iconWrapper {
       color: #ffffff;

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -10,34 +10,43 @@ import {
 
 import styles from './FeatureBoxes.module.scss';
 import FeatureBox from '../../common/FeatureBox/FeatureBox';
+import { Link } from 'react-router-dom';
 
 const FeatureBoxes = () => (
   <div className={styles.root}>
     <div className='container'>
       <div className='row'>
         <div className='col'>
-          <FeatureBox icon={faTruck} active>
-            <h5>Free shipping</h5>
-            <p>All orders</p>
-          </FeatureBox>
+          <Link className={styles.link} to='/'>
+            <FeatureBox icon={faTruck}>
+              <h5>Free shipping</h5>
+              <p>All orders</p>
+            </FeatureBox>
+          </Link>
         </div>
         <div className='col'>
-          <FeatureBox icon={faHeadphones}>
-            <h5>24/7 customer</h5>
-            <p>support</p>
-          </FeatureBox>
+          <Link className={styles.link} to='/'>
+            <FeatureBox icon={faHeadphones}>
+              <h5>24/7 customer</h5>
+              <p>support</p>
+            </FeatureBox>
+          </Link>
         </div>
         <div className='col'>
-          <FeatureBox icon={faReplyAll}>
-            <h5>Money back</h5>
-            <p>guarantee</p>
-          </FeatureBox>
+          <Link className={styles.link} to='/'>
+            <FeatureBox icon={faReplyAll}>
+              <h5>Money back</h5>
+              <p>guarantee</p>
+            </FeatureBox>
+          </Link>
         </div>
         <div className='col'>
-          <FeatureBox icon={faBullhorn}>
-            <h5>Member discount</h5>
-            <p>First order</p>
-          </FeatureBox>
+          <Link className={styles.link} to='/'>
+            <FeatureBox icon={faBullhorn}>
+              <h5>Member discount</h5>
+              <p>First order</p>
+            </FeatureBox>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -3,3 +3,7 @@
 .root {
   padding: 5rem 0;
 }
+
+.link:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
Problemem był hover przypisany na sztywno do pierwszego elementu z listy korzyści oraz żaden z elementów nie był linkiem.  Aktualnie każdy z elementów jest linkiem oraz hover znajduje się na aktualnie wybranym elemencie.